### PR TITLE
Update draw.io webjar coordinates

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -141,7 +141,7 @@ var mxLanguage = '$xcontext.locale';
 var mxGraphEditorBasePath = "$services.webjars.url('org.xwiki.contrib:mxgraph-editor', '')";
 
 // Diagram Editor Configuration
-var diagramEditorBasePath = "$services.webjars.url('org.xwiki.contrib:draw.io', '')";
+var diagramEditorBasePath = "$services.webjars.url('de.seclution.xwiki:drawio-webjar', '')";
 var RESOURCES_PATH = diagramEditorBasePath + 'resources';
 // Comment out the following line when using the basic mxGraph Editor.
 var RESOURCE_BASE = RESOURCES_PATH + '/dia';

--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -148,7 +148,7 @@ var mxLoadResources = false;
 var mxGraphViewerBasePath = "$services.webjars.url('org.xwiki.contrib:mxgraph-editor', '')";
 
 // Diagram Viewer Configuration
-var diagramViewerBasePath = "$services.webjars.url('org.xwiki.contrib:draw.io', '')";
+var diagramViewerBasePath = "$services.webjars.url('de.seclution.xwiki:drawio-webjar', '')";
 var STENCIL_PATH = diagramViewerBasePath + 'stencils';
 var IMAGE_PATH = diagramViewerBasePath + 'images';
 var STYLE_PATH = CSS_PATH = diagramViewerBasePath + 'styles';


### PR DESCRIPTION
## Summary
- update DiagramEditSheet and DiagramViewSheet to use the new draw.io webjar groupId

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ba0b6dc4083218f1a5a699844b3b8