### PR TITLE
Update draw.io dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,9 @@
       <artifactId>jquery</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.xwiki.contrib</groupId>
-      <artifactId>draw.io</artifactId>
-      <version>6.5.7</version>
+      <groupId>de.seclution.xwiki</groupId>
+      <artifactId>drawio-webjar</artifactId>
+      <version>22.0.3</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -141,7 +141,7 @@ var mxLanguage = '$xcontext.locale';
 var mxGraphEditorBasePath = "$services.webjars.url('org.xwiki.contrib:mxgraph-editor', '')";
 
 // Diagram Editor Configuration
-var diagramEditorBasePath = "$services.webjars.url('org.xwiki.contrib:draw.io', '')";
+var diagramEditorBasePath = "$services.webjars.url('de.seclution.xwiki:drawio-webjar', '')";
 var RESOURCES_PATH = diagramEditorBasePath + 'resources';
 // Comment out the following line when using the basic mxGraph Editor.
 var RESOURCE_BASE = RESOURCES_PATH + '/dia';

--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -148,7 +148,7 @@ var mxLoadResources = false;
 var mxGraphViewerBasePath = "$services.webjars.url('org.xwiki.contrib:mxgraph-editor', '')";
 
 // Diagram Viewer Configuration
-var diagramViewerBasePath = "$services.webjars.url('org.xwiki.contrib:draw.io', '')";
+var diagramViewerBasePath = "$services.webjars.url('de.seclution.xwiki:drawio-webjar', '')";
 var STENCIL_PATH = diagramViewerBasePath + 'stencils';
 var IMAGE_PATH = diagramViewerBasePath + 'images';
 var STYLE_PATH = CSS_PATH = diagramViewerBasePath + 'styles';


### PR DESCRIPTION
## Summary
- switch to `de.seclution.xwiki:drawio-webjar`
- update JS base paths to match the new webjar

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_685ba0b9f2c48321bd6b1c4d6616ad64