### PR TITLE
Add build instructions and workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,28 @@
+name: Package XAR
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master, main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Build XAR
+        run: mvn -B package
+      - name: Zip XAR
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          zip -j application-diagram-${VERSION}.zip target/application-diagram-${VERSION}.xar
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: application-diagram-xar
+          path: application-diagram-*.zip

--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ This is a simple application created using [AppWithinMinutes](http://extensions.
 * Translations: N/A
 * Sonar Dashboard: N/A
 * Continuous Integration Status: [![Build Status](https://ci.xwiki.org/job/XWiki%20Contrib/job/application-diagram/job/master/badge/icon)](https://ci.xwiki.org/view/Contrib/job/XWiki%20Contrib/job/application-diagram/job/master/)
+
+## Building
+
+Run the following command from the project root to generate the `.xar` package:
+
+```bash
+mvn package
+```
+
+The resulting file will be located under `target/` as `application-diagram-<version>.xar`.
+You can also trigger the `Package XAR` GitHub workflow to build and archive this file automatically.


### PR DESCRIPTION
## Summary
- document how to build the XAR with Maven
- add a GitHub Actions workflow that packages the project

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_685ba0bc3cf0832184a4e7bc113fc1f0